### PR TITLE
Fix wrong state changing when error happens

### DIFF
--- a/src/sources/source.ts
+++ b/src/sources/source.ts
@@ -150,7 +150,7 @@ export class Source<T extends Object = {}> extends EventEmitterMixin<Events, typ
 			this.state = 'READY';
 			this.trigger('load', undefined);
 		} catch (e) {
-			this.state == 'ERROR';
+			this.state = 'ERROR';
 			this.trigger('error', new Error(String(e)));
 			throw e;
 		}

--- a/src/sources/video.ts
+++ b/src/sources/video.ts
@@ -80,7 +80,7 @@ export class VideoSource<T extends Object = {}> extends AudioSource<T> {
 			this.file = new File([blob], this.name, { type: blob.type });
 			this.trigger('load', undefined);
 		} catch (e) {
-			this.state == 'ERROR';
+			this.state = 'ERROR';
 			this.trigger('error', new Error(String(e)));
 		} finally {
 			this.downloadInProgress = false;


### PR DESCRIPTION
When error happens, ```this.state == 'ERROR';``` makes no sense, we need to set the state to be ERROR instead of having a check. 